### PR TITLE
MTDSA-12875: Add TYS support for Delete UK Dividends Income Annual Summary

### DIFF
--- a/app/v1/connectors/DeleteUkDividendsIncomeAnnualSummaryConnector.scala
+++ b/app/v1/connectors/DeleteUkDividendsIncomeAnnualSummaryConnector.scala
@@ -17,8 +17,9 @@
 package v1.connectors
 
 import api.connectors.{BaseDownstreamConnector, DownstreamOutcome}
-import api.connectors.DownstreamUri.DesUri
+import api.connectors.DownstreamUri.{DesUri, TaxYearSpecificIfsUri}
 import config.AppConfig
+
 import javax.inject.{Inject, Singleton}
 import play.api.libs.json.JsObject
 import uk.gov.hmrc.http.{HeaderCarrier, HttpClient}
@@ -36,16 +37,19 @@ class DeleteUkDividendsIncomeAnnualSummaryConnector @Inject() (val http: HttpCli
       correlationId: String): Future[DownstreamOutcome[Unit]] = {
 
     import api.connectors.httpparsers.StandardDownstreamHttpParser._
-
-    val nino    = request.nino.nino
-    val taxYear = request.taxYear.asDownstream
+    import request.nino.nino
+    import request.taxYear
 
     implicit val successCode: SuccessCode = SuccessCode(NO_CONTENT)
 
-    post(
-      uri = DesUri[Unit](s"income-tax/nino/$nino/income-source/dividends/annual/$taxYear"),
-      body = JsObject.empty
-    )
+    val downstreamUri =
+      if (taxYear.useTaxYearSpecificApi) {
+        TaxYearSpecificIfsUri[Unit](s"income-tax/${taxYear.asTysDownstream}/$nino/income-source/dividends/annual")
+      } else {
+        DesUri[Unit](s"income-tax/nino/$nino/income-source/dividends/annual/${taxYear.asDownstream}")
+      }
+
+    post(uri = downstreamUri, body = JsObject.empty)
   }
 
 }

--- a/app/v1/controllers/DeleteUkDividendsIncomeAnnualSummaryController.scala
+++ b/app/v1/controllers/DeleteUkDividendsIncomeAnnualSummaryController.scala
@@ -114,7 +114,14 @@ class DeleteUkDividendsIncomeAnnualSummaryController @Inject() (val authService:
 
   private def errorResult(errorWrapper: ErrorWrapper) =
     errorWrapper.error match {
-      case BadRequestError | NinoFormatError | TaxYearFormatError | RuleTaxYearRangeInvalidError | RuleTaxYearNotSupportedError =>
+      case _
+        if errorWrapper.containsAnyOf(
+          BadRequestError,
+          NinoFormatError,
+          TaxYearFormatError,
+          RuleTaxYearRangeInvalidError,
+          RuleTaxYearNotSupportedError
+        ) =>
         BadRequest(Json.toJson(errorWrapper))
       case NotFoundError           => NotFound(Json.toJson(errorWrapper))
       case StandardDownstreamError => InternalServerError(Json.toJson(errorWrapper))

--- a/app/v1/services/DeleteUkDividendsIncomeAnnualSummaryService.scala
+++ b/app/v1/services/DeleteUkDividendsIncomeAnnualSummaryService.scala
@@ -40,15 +40,13 @@ class DeleteUkDividendsIncomeAnnualSummaryService @Inject() (connector: DeleteUk
       logContext: EndpointLogContext,
       correlationId: String): Future[Either[ErrorWrapper, ResponseWrapper[Unit]]] = {
 
-    val result = for {
-      desResponseWrapper <- EitherT(connector.delete(request)).leftMap(mapDownstreamErrors(desErrorMap))
-    } yield desResponseWrapper
+    val result = EitherT(connector.delete(request)).leftMap(mapDownstreamErrors(errorMap))
 
     result.value
   }
 
-  private def desErrorMap: Map[String, MtdError] =
-    Map(
+  private def errorMap: Map[String, MtdError] = {
+    val errors = Map(
       "INVALID_NINO"                      -> NinoFormatError,
       "INVALID_TYPE"                      -> StandardDownstreamError,
       "INVALID_TAXYEAR"                   -> TaxYearFormatError,
@@ -64,5 +62,17 @@ class DeleteUkDividendsIncomeAnnualSummaryService @Inject() (connector: DeleteUk
       "GONE"                              -> NotFoundError,
       "NOT_FOUND"                         -> NotFoundError
     )
+
+    val extraTysErrors = Map(
+      "INVALID_INCOMESOURCE_TYPE" -> StandardDownstreamError,
+      "INVALID_TAX_YEAR" -> TaxYearFormatError,
+      "INVALID_CORRELATIONID" -> StandardDownstreamError,
+      "INCOME_SOURCE_NOT_FOUND" -> NotFoundError,
+      "INCOMPATIBLE_INCOME_SOURCE" -> StandardDownstreamError,
+      "TAX_YEAR_NOT_SUPPORTED" -> RuleTaxYearNotSupportedError
+    )
+
+    errors ++ extraTysErrors
+  }
 
 }

--- a/it/v1/endpoints/DeleteUkDividendsIncomeAnnualSummaryControllerISpec.scala
+++ b/it/v1/endpoints/DeleteUkDividendsIncomeAnnualSummaryControllerISpec.scala
@@ -21,47 +21,46 @@ import api.stubs.{AuditStub, AuthStub, DownstreamStub, MtdIdLookupStub}
 import com.github.tomakehurst.wiremock.stubbing.StubMapping
 import play.api.http.HeaderNames.ACCEPT
 import play.api.http.Status._
-import play.api.libs.json.Json
+import play.api.libs.json.{JsObject, Json}
 import play.api.libs.ws.{WSRequest, WSResponse}
 import play.api.test.Helpers.AUTHORIZATION
 import support.IntegrationBaseSpec
 
 class DeleteUkDividendsIncomeAnnualSummaryControllerISpec extends IntegrationBaseSpec {
 
-  private trait Test {
-
-    val nino: String    = "AA123456A"
-    val taxYear: String = "2017-18"
-    val desTaxYear: String = "2018"
-
-    def uri: String = s"/uk-dividends/$nino/$taxYear"
-
-    def desUri: String = s"/income-tax/nino/$nino/income-source/dividends/annual/$desTaxYear"
-
-    def setupStubs(): StubMapping
-
-    def request(): WSRequest = {
-      setupStubs()
-      buildRequest(uri)
-        .withHttpHeaders(
-          (ACCEPT, "application/vnd.hmrc.1.0+json"),
-          (AUTHORIZATION, "Bearer 123") // some bearer token
-      )
-    }
-  }
-
   "Calling the 'delete uk dividends income' endpoint" should {
     "return a 204 status code" when {
-      "any valid request is made" in new Test {
+      "any valid request is made" in new NonTysTest {
 
         override def setupStubs(): StubMapping = {
           AuditStub.audit()
           AuthStub.authorised()
           MtdIdLookupStub.ninoFound(nino)
-          DownstreamStub.onSuccess(DownstreamStub.POST, desUri, NO_CONTENT)
+          DownstreamStub
+            .when(method = DownstreamStub.POST, uri = downstreamUri)
+            .withRequestBody(JsObject.empty)
+            .thenReturn(status = NO_CONTENT)
         }
 
-        val response: WSResponse = await(request().delete)
+        val response: WSResponse = await(mtdRequest.delete)
+        response.status shouldBe NO_CONTENT
+        response.body shouldBe ""
+        response.header("Content-Type") shouldBe Some("application/json")
+      }
+
+      "any valid request is made for a Tax Year Specific tax year" in new TysIfsTest {
+
+        override def setupStubs(): StubMapping = {
+          AuditStub.audit()
+          AuthStub.authorised()
+          MtdIdLookupStub.ninoFound(nino)
+          DownstreamStub
+            .when(method = DownstreamStub.POST, uri = downstreamUri)
+            .withRequestBody(JsObject.empty)
+            .thenReturn(status = NO_CONTENT)
+        }
+
+        val response: WSResponse = await(mtdRequest.delete)
         response.status shouldBe NO_CONTENT
         response.body shouldBe ""
         response.header("Content-Type") shouldBe Some("application/json")
@@ -72,7 +71,7 @@ class DeleteUkDividendsIncomeAnnualSummaryControllerISpec extends IntegrationBas
 
       "validation error" when {
         def validationErrorTest(requestNino: String, requestTaxYear: String, expectedStatus: Int, expectedBody: MtdError): Unit = {
-          s"validation fails with ${expectedBody.code} error" in new Test {
+          s"validation fails with ${expectedBody.code} error" in new NonTysTest {
 
             override val nino: String    = requestNino
             override val taxYear: String = requestTaxYear
@@ -83,7 +82,7 @@ class DeleteUkDividendsIncomeAnnualSummaryControllerISpec extends IntegrationBas
               MtdIdLookupStub.ninoFound(nino)
             }
 
-            val response: WSResponse = await(request().delete)
+            val response: WSResponse = await(mtdRequest().delete)
             response.status shouldBe expectedStatus
             response.json shouldBe Json.toJson(expectedBody)
             response.header("Content-Type") shouldBe Some("application/json")
@@ -99,32 +98,32 @@ class DeleteUkDividendsIncomeAnnualSummaryControllerISpec extends IntegrationBas
         input.foreach(args => (validationErrorTest _).tupled(args))
       }
 
-      "des service error" when {
-        "des returns a 200 response" in new Test {
+      "downstream service error" when {
+        "downstream returns a 200 response" in new NonTysTest {
           override def setupStubs(): StubMapping = {
             AuditStub.audit()
             AuthStub.authorised()
             MtdIdLookupStub.ninoFound(nino)
-            DownstreamStub.onSuccess(DownstreamStub.POST, desUri, OK)
+            DownstreamStub.onSuccess(DownstreamStub.POST, downstreamUri, OK)
           }
 
-          val response: WSResponse = await(request().delete)
+          val response: WSResponse = await(mtdRequest().delete)
           response.status shouldBe INTERNAL_SERVER_ERROR
           response.json shouldBe Json.toJson(StandardDownstreamError)
           response.header("Content-Type") shouldBe Some("application/json")
         }
 
-        def serviceErrorTest(ifsStatus: Int, ifsCode: String, expectedStatus: Int, expectedBody: MtdError): Unit = {
-          s"des returns an $ifsCode error and status $ifsStatus" in new Test {
+        def downstreamServiceErrorTest(downstreamStatus: Int, downstreamCode: String, expectedStatus: Int, expectedBody: MtdError): Unit = {
+          s"downstream returns an $downstreamCode error and status $downstreamStatus" in new NonTysTest {
 
             override def setupStubs(): StubMapping = {
               AuditStub.audit()
               AuthStub.authorised()
               MtdIdLookupStub.ninoFound(nino)
-              DownstreamStub.onError(DownstreamStub.POST, desUri, ifsStatus, errorBody(ifsCode))
+              DownstreamStub.onError(DownstreamStub.POST, downstreamUri, downstreamStatus, errorBody(downstreamCode))
             }
 
-            val response: WSResponse = await(request().delete)
+            val response: WSResponse = await(mtdRequest().delete)
             response.status shouldBe expectedStatus
             response.json shouldBe Json.toJson(expectedBody)
             response.header("Content-Type") shouldBe Some("application/json")
@@ -135,11 +134,11 @@ class DeleteUkDividendsIncomeAnnualSummaryControllerISpec extends IntegrationBas
           s"""
              |{
              |   "code": "$code",
-             |   "reason": "ifs message"
+             |   "reason": "downstream message"
              |}
             """.stripMargin
 
-        val input = Seq(
+        val errors = Seq(
           (BAD_REQUEST, "INVALID_NINO", BAD_REQUEST, NinoFormatError),
           (BAD_REQUEST, "INVALID_TYPE", INTERNAL_SERVER_ERROR, StandardDownstreamError),
           (BAD_REQUEST, "INVALID_TAXYEAR", BAD_REQUEST, TaxYearFormatError),
@@ -156,8 +155,55 @@ class DeleteUkDividendsIncomeAnnualSummaryControllerISpec extends IntegrationBas
           (NOT_FOUND, "NOT_FOUND", NOT_FOUND, NotFoundError),
           (UNPROCESSABLE_ENTITY, "INVALID_PAYLOAD", INTERNAL_SERVER_ERROR, StandardDownstreamError)
         )
-        input.foreach(args => (serviceErrorTest _).tupled(args))
+
+        val extraTysErrors = Seq(
+          (BAD_REQUEST, "INVALID_INCOMESOURCE_TYPE", INTERNAL_SERVER_ERROR, StandardDownstreamError),
+          (BAD_REQUEST, "INVALID_TAX_YEAR", BAD_REQUEST, TaxYearFormatError),
+          (BAD_REQUEST, "INVALID_CORRELATIONID", INTERNAL_SERVER_ERROR, StandardDownstreamError),
+          (NOT_FOUND, "INCOME_SOURCE_NOT_FOUND", NOT_FOUND, NotFoundError),
+          (UNPROCESSABLE_ENTITY, "INCOMPATIBLE_INCOME_SOURCE", INTERNAL_SERVER_ERROR, StandardDownstreamError),
+          (UNPROCESSABLE_ENTITY, "TAX_YEAR_NOT_SUPPORTED", BAD_REQUEST, RuleTaxYearNotSupportedError),
+        )
+
+        (errors ++ extraTysErrors).foreach(args => (downstreamServiceErrorTest _).tupled(args))
       }
     }
   }
+
+  private trait Test {
+
+    def taxYear: String
+    def downstreamTaxYear: String
+    def downstreamUri: String
+
+    def nino: String = "AA123456A"
+
+    def setupStubs(): StubMapping
+
+    def mtdRequest(): WSRequest = {
+      setupStubs()
+      buildRequest(s"/uk-dividends/$nino/$taxYear")
+        .withHttpHeaders(
+          (ACCEPT, "application/vnd.hmrc.1.0+json"),
+          (AUTHORIZATION, "Bearer 123") // some bearer token
+        )
+    }
+  }
+
+  private trait NonTysTest extends Test {
+    def taxYear: String = "2020-21"
+
+    def downstreamTaxYear: String = "2021"
+
+    def downstreamUri: String = s"/income-tax/nino/$nino/income-source/dividends/annual/$downstreamTaxYear"
+  }
+
+  private trait TysIfsTest extends Test {
+    def taxYear: String = "2023-24"
+
+    def downstreamTaxYear: String = "23-24"
+
+    def downstreamUri: String = s"/income-tax/$downstreamTaxYear/$nino/income-source/dividends/annual"
+  }
+
 }

--- a/test/v1/services/DeleteUkDividendsIncomeSummaryServiceSpec.scala
+++ b/test/v1/services/DeleteUkDividendsIncomeSummaryServiceSpec.scala
@@ -67,7 +67,7 @@ class DeleteUkDividendsIncomeSummaryServiceSpec extends UnitSpec {
           await(service.delete(requestData)) shouldBe Left(ErrorWrapper("resultId", error))
         }
 
-      val input = Seq(
+      val errors = Seq(
         ("INVALID_NINO", NinoFormatError),
         ("INVALID_TYPE", StandardDownstreamError),
         ("INVALID_TAXYEAR", TaxYearFormatError),
@@ -84,7 +84,16 @@ class DeleteUkDividendsIncomeSummaryServiceSpec extends UnitSpec {
         ("NOT_FOUND", NotFoundError)
       )
 
-      input.foreach(args => (serviceError _).tupled(args))
+      val extraTysErrors = Seq(
+        ("INVALID_INCOMESOURCE_TYPE", StandardDownstreamError),
+        ("INVALID_TAX_YEAR", TaxYearFormatError),
+        ("INVALID_CORRELATIONID", StandardDownstreamError),
+        ("INCOME_SOURCE_NOT_FOUND", NotFoundError),
+        ("INCOMPATIBLE_INCOME_SOURCE", StandardDownstreamError),
+        ("TAX_YEAR_NOT_SUPPORTED", RuleTaxYearNotSupportedError),
+      )
+
+      (errors ++ extraTysErrors).foreach(args => (serviceError _).tupled(args))
     }
   }
 }


### PR DESCRIPTION
- Ticket: [MTDSA-12875](https://jira.tools.tax.service.gov.uk/browse/MTDSA-12875)
- Spec: [API#1784(1390) - Delete a UK dividends income annual summary (TY 23-24)](https://confluence.tools.tax.service.gov.uk/pages/viewpage.action?pageId=515212413)