### PR TITLE
Add suspend-temporal-validations header to suspend validations

### DIFF
--- a/app/config/FeatureSwitches.scala
+++ b/app/config/FeatureSwitches.scala
@@ -44,10 +44,10 @@ case class FeatureSwitches(featureSwitchConfig: Configuration) {
   val isTaxYearSpecificApiEnabled: Boolean  = isEnabled("tys-api.enabled")
 
   def isTemporalValidationEnabled(implicit request: Request[_]): Boolean = {
-    if (!isEnabled("allowTemporalValidationSuspension.enabled")) {
-      true
-    } else {
+    if (isEnabled("allowTemporalValidationSuspension.enabled")) {
       request.headers.get("suspend-temporal-validations").forall(!BooleanUtils.toBoolean(_))
+    } else {
+      true
     }
   }
 

--- a/app/config/FeatureSwitches.scala
+++ b/app/config/FeatureSwitches.scala
@@ -16,7 +16,9 @@
 
 package config
 
+import org.apache.commons.lang3.BooleanUtils
 import play.api.Configuration
+import play.api.mvc.Request
 
 case class FeatureSwitches(featureSwitchConfig: Configuration) {
 
@@ -40,6 +42,14 @@ case class FeatureSwitches(featureSwitchConfig: Configuration) {
   val isV1R7cRoutingEnabled: Boolean        = isEnabled("v1r7c-endpoints.enabled")
   val isTaxYearNotEndedRuleEnabled: Boolean = isEnabled("taxYearNotEndedRule.enabled")
   val isTaxYearSpecificApiEnabled: Boolean  = isEnabled("tys-api.enabled")
+
+  def isTemporalValidationEnabled(implicit request: Request[_]): Boolean = {
+    if (!isEnabled("allowTemporalValidationSuspension.enabled")) {
+      true
+    } else {
+      request.headers.get("suspend-temporal-validations").forall(!BooleanUtils.toBoolean(_))
+    }
+  }
 
   private def isEnabled(key: String): Boolean = featureSwitchConfig.getOptional[Boolean](key).getOrElse(true)
 }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -146,6 +146,8 @@ feature-switch {
   tys-api {
     enabled = true
   }
+
+  allowTemporalValidationSuspension.enabled = true
 }
 
 microservice {

--- a/test/api/controllers/ControllerBaseSpec.scala
+++ b/test/api/controllers/ControllerBaseSpec.scala
@@ -19,8 +19,6 @@ package api.controllers
 import api.models.errors._
 import api.models.hateoas.Link
 import api.models.hateoas.Method.GET
-import mocks.MockAppConfig
-import play.api.Configuration
 import play.api.http.{HeaderNames, MimeTypes, Status}
 import play.api.libs.json.{JsObject, Json}
 import play.api.mvc.{AnyContentAsEmpty, ControllerComponents}
@@ -29,7 +27,6 @@ import play.api.test.{FakeRequest, ResultExtractors}
 import support.UnitSpec
 
 class ControllerBaseSpec extends UnitSpec with Status with MimeTypes with HeaderNames with ResultExtractors {
-  _: MockAppConfig =>
 
   implicit lazy val fakeRequest: FakeRequest[AnyContentAsEmpty.type] = FakeRequest()
 
@@ -68,8 +65,4 @@ class ControllerBaseSpec extends UnitSpec with Status with MimeTypes with Header
       "SERVER_ERROR"              -> StandardDownstreamError,
       "SERVICE_UNAVAILABLE"       -> StandardDownstreamError
     )
-
-  def temporalValidation(enabled: Boolean): Unit =
-    MockedAppConfig.featureSwitches returns Configuration("allowTemporalValidationSuspension.enabled" -> enabled) anyNumberOfTimes ()
-
 }

--- a/test/api/controllers/ControllerBaseSpec.scala
+++ b/test/api/controllers/ControllerBaseSpec.scala
@@ -19,6 +19,8 @@ package api.controllers
 import api.models.errors._
 import api.models.hateoas.Link
 import api.models.hateoas.Method.GET
+import mocks.MockAppConfig
+import play.api.Configuration
 import play.api.http.{HeaderNames, MimeTypes, Status}
 import play.api.libs.json.{JsObject, Json}
 import play.api.mvc.{AnyContentAsEmpty, ControllerComponents}
@@ -27,6 +29,7 @@ import play.api.test.{FakeRequest, ResultExtractors}
 import support.UnitSpec
 
 class ControllerBaseSpec extends UnitSpec with Status with MimeTypes with HeaderNames with ResultExtractors {
+  _: MockAppConfig =>
 
   implicit lazy val fakeRequest: FakeRequest[AnyContentAsEmpty.type] = FakeRequest()
 
@@ -65,5 +68,8 @@ class ControllerBaseSpec extends UnitSpec with Status with MimeTypes with Header
       "SERVER_ERROR"              -> StandardDownstreamError,
       "SERVICE_UNAVAILABLE"       -> StandardDownstreamError
     )
+
+  def temporalValidation(enabled: Boolean): Unit =
+    MockedAppConfig.featureSwitches returns Configuration("allowTemporalValidationSuspension.enabled" -> enabled) anyNumberOfTimes ()
 
 }

--- a/test/config/FeatureSwitchesSpec.scala
+++ b/test/config/FeatureSwitchesSpec.scala
@@ -17,6 +17,8 @@
 package config
 
 import play.api.Configuration
+import play.api.mvc.Headers
+import play.api.test.FakeRequest
 import support.UnitSpec
 
 class FeatureSwitchesSpec extends UnitSpec {
@@ -42,7 +44,7 @@ class FeatureSwitchesSpec extends UnitSpec {
 
     "be false" when {
       "disabled" in {
-        val configuration = Configuration("tys-api.enabled" -> false)
+        val configuration   = Configuration("tys-api.enabled" -> false)
         val featureSwitches = FeatureSwitches(configuration)
 
         featureSwitches.isTaxYearSpecificApiEnabled shouldBe false
@@ -82,6 +84,50 @@ class FeatureSwitchesSpec extends UnitSpec {
         featureSwitches.isVersionEnabled("1.0") shouldBe true
       }
     }
+  }
+
+  "isTemporalValidationEnabled" when {
+
+    def configuration(enable: Boolean) =
+      Configuration("allowTemporalValidationSuspension.enabled" -> enable)
+
+    def requestWith(headers: Headers) =
+      FakeRequest("GET", "someUrl", headers, None)
+
+    def headers(suspend: String) = Headers("suspend-temporal-validations" -> suspend)
+
+    "the suspension enabling feature switch is false" should {
+      val featureSwitches = FeatureSwitches(configuration(false))
+
+      "return true even if the suspend header is present and true" in {
+        featureSwitches.isTemporalValidationEnabled(requestWith(headers(suspend = "true"))) shouldBe true
+      }
+
+      "return true even if the suspend header is not present" in {
+        featureSwitches.isTemporalValidationEnabled(requestWith(Headers())) shouldBe true
+      }
+    }
+
+    "the suspension enabling feature switch is true" should {
+      val featureSwitches = FeatureSwitches(configuration(true))
+
+      "return false if the suspend header is present and true" in {
+        featureSwitches.isTemporalValidationEnabled(requestWith(headers(suspend = "true"))) shouldBe false
+      }
+
+      "return true if the suspend header is present and false" in {
+        featureSwitches.isTemporalValidationEnabled(requestWith(headers(suspend = "false"))) shouldBe true
+      }
+
+      "return true if the suspend header is not present" in {
+        featureSwitches.isTemporalValidationEnabled(requestWith(Headers())) shouldBe true
+      }
+
+      "return true if the suspend header is not a valid boolean" in {
+        featureSwitches.isTemporalValidationEnabled(requestWith(headers(suspend = "not a boolean"))) shouldBe true
+      }
+    }
+
   }
 
 }

--- a/test/config/FeatureSwitchesSpec.scala
+++ b/test/config/FeatureSwitchesSpec.scala
@@ -103,7 +103,7 @@ class FeatureSwitchesSpec extends UnitSpec {
         featureSwitches.isTemporalValidationEnabled(requestWith(headers(suspend = "true"))) shouldBe true
       }
 
-      "return true even if the suspend header is not present" in {
+      "return true if the suspend header is not present" in {
         featureSwitches.isTemporalValidationEnabled(requestWith(Headers())) shouldBe true
       }
     }


### PR DESCRIPTION
 (when feature switch allowTemporalValidationSuspension.enabled)

Idea is that:
(1) The RawData for the endpoints to make use of this is extended with a new boolean field e.g. 
```
case class CreateAmendCgtPpdOverridesRawData(nino: String, taxYear: String, temporalValidationEnabled: Boolean, ...) extends RawData
```

(2) Controllers populate this with the value if `FeatureSwitches()(appConfig).isTemporalValidationEnabled`
(3) ControllerSpecs can mock isTemporalValidationEnabled by calling 
```
MockedAppConfig.featureSwitches returns Configuration("allowTemporalValidationSuspension.enabled" -> true) anyNumberOfTimes()
```
(3) Endpoint Validators can ignore validation that relies on the current date when this is false.
(4) Integration tests, PTs and ATs can send through the "suspend-temporal-validations" header with a value of "true" for TYS tests that fail otherwise.