### PR TITLE
MTDSA-14021: Add new lines to application.yaml description for correct formatting

### DIFF
--- a/resources/public/api/conf/1.0/application.yaml
+++ b/resources/public/api/conf/1.0/application.yaml
@@ -6,6 +6,7 @@ info:
   description: |
     # Send fraud prevention data
     HMRC monitors transactions to help protect your customers' confidential data from criminals and fraudsters. 
+    
     <div class="govuk-warning-text warning-icon-fix">
       <span class="govuk-warning-text__icon warning-icon-ui-fix" aria-hidden="true">!</span>
       <strong class="govuk-warning-text__text">
@@ -13,7 +14,9 @@ info:
         You are required by law to submit header data for this API. This includes all associated APIs and endpoints.
       </strong>
     </div>
+    
     [Check the data you need to send](/guides/fraud-prevention/). You can also use the [Test API](/api-documentation/docs/api/service/txm-fph-validator-api/1.0) during initial development and as part of your quality assurance checks.
+    
     # Changelog
     The changelog is [available here](https://github.com/hmrc/income-tax-mtd-changelog).
     


### PR DESCRIPTION
Apparently the lack of new lines was causing some formatting issues with the API description.