### PR TITLE
MTDSA-25055 - fix mapping for 403 from mtd-identifier-lookup

### DIFF
--- a/app/api/connectors/MtdIdLookupConnector.scala
+++ b/app/api/connectors/MtdIdLookupConnector.scala
@@ -22,12 +22,20 @@ import uk.gov.hmrc.http.{HeaderCarrier, HttpClient}
 import javax.inject.{Inject, Singleton}
 import scala.concurrent.{ExecutionContext, Future}
 
+object MtdIdLookupConnector {
+  case class Error(statusCode: Int) extends AnyVal
+
+  type Outcome = Either[MtdIdLookupConnector.Error, String]
+
+}
+
 @Singleton
 class MtdIdLookupConnector @Inject() (http: HttpClient, appConfig: AppConfig) {
 
-  def getMtdId(nino: String)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[MtdIdLookupOutcome] = {
+  def getMtdId(nino: String)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[MtdIdLookupConnector.Outcome] = {
     import api.connectors.httpparsers.MtdIdLookupHttpParser.mtdIdLookupHttpReads
-    http.GET[MtdIdLookupOutcome](s"${appConfig.mtdIdBaseUrl}/mtd-identifier-lookup/nino/$nino")
+
+    http.GET[MtdIdLookupConnector.Outcome](s"${appConfig.mtdIdBaseUrl}/mtd-identifier-lookup/nino/$nino")
   }
 
 }

--- a/app/api/connectors/httpparsers/MtdIdLookupHttpParser.scala
+++ b/app/api/connectors/httpparsers/MtdIdLookupHttpParser.scala
@@ -16,9 +16,9 @@
 
 package api.connectors.httpparsers
 
-import api.connectors.MtdIdLookupOutcome
-import api.models.errors.{InternalError, InvalidBearerTokenError, NinoFormatError}
-import play.api.http.Status.{FORBIDDEN, OK, UNAUTHORIZED}
+import api.connectors
+import api.connectors.MtdIdLookupConnector
+import play.api.http.Status.OK
 import play.api.libs.json._
 import uk.gov.hmrc.http.{HttpReads, HttpResponse}
 
@@ -26,16 +26,10 @@ object MtdIdLookupHttpParser extends HttpParser {
 
   private val mtdIdJsonReads: Reads[String] = (__ \ "mtdbsa").read[String]
 
-  implicit val mtdIdLookupHttpReads: HttpReads[MtdIdLookupOutcome] = (_: String, _: String, response: HttpResponse) => {
+  implicit val mtdIdLookupHttpReads: HttpReads[connectors.MtdIdLookupConnector.Outcome] = (_: String, _: String, response: HttpResponse) => {
     response.status match {
-      case OK =>
-        response.validateJson[String](mtdIdJsonReads) match {
-          case Some(mtdId) => Right(mtdId)
-          case None        => Left(InternalError)
-        }
-      case FORBIDDEN    => Left(NinoFormatError)
-      case UNAUTHORIZED => Left(InvalidBearerTokenError)
-      case _            => Left(InternalError)
+      case OK     => Right(response.json.as[String](mtdIdJsonReads))
+      case status => Left(MtdIdLookupConnector.Error(status))
     }
   }
 

--- a/app/api/connectors/package.scala
+++ b/app/api/connectors/package.scala
@@ -16,12 +16,10 @@
 
 package api
 
-import api.models.errors.{DownstreamError, MtdError}
+import api.models.errors.DownstreamError
 import api.models.outcomes.ResponseWrapper
 
 package object connectors {
-
-  type MtdIdLookupOutcome = Either[MtdError, String]
 
   type DownstreamOutcome[A] = Either[ResponseWrapper[DownstreamError], ResponseWrapper[A]]
 }

--- a/app/api/controllers/AuthorisedController.scala
+++ b/app/api/controllers/AuthorisedController.scala
@@ -17,7 +17,7 @@
 package api.controllers
 
 import api.models.auth.UserDetails
-import api.models.errors.{ClientNotAuthenticatedError, InternalError, MtdError}
+import api.models.errors.MtdError
 import api.services.{EnrolmentsAuthService, MtdIdLookupService}
 import play.api.mvc._
 import uk.gov.hmrc.auth.core.Enrolment
@@ -46,11 +46,10 @@ abstract class AuthorisedController(cc: ControllerComponents)(implicit ec: Execu
         .withDelegatedAuthRule("mtd-it-auth")
 
     def invokeBlockWithAuthCheck[A](mtdId: String, request: Request[A], block: UserRequest[A] => Future[Result])(implicit
-        headerCarrier: HeaderCarrier): Future[Result] = {
+                                                                                                                 headerCarrier: HeaderCarrier): Future[Result] = {
       authService.authorised(predicate(mtdId)).flatMap[Result] {
-        case Right(userDetails)                => block(UserRequest(userDetails.copy(mtdId = mtdId), request))
-        case Left(ClientNotAuthenticatedError) => Future.successful(Forbidden(ClientNotAuthenticatedError.asJson))
-        case Left(_)                           => Future.successful(InternalServerError(InternalError.asJson))
+        case Right(userDetails) => block(UserRequest(userDetails.copy(mtdId = mtdId), request))
+        case Left(mtdError)     => errorResponse(mtdError)
       }
     }
 

--- a/app/api/controllers/requestParsers/validators/validations/NinoValidation.scala
+++ b/app/api/controllers/requestParsers/validators/validations/NinoValidation.scala
@@ -25,8 +25,10 @@ object NinoValidation {
     "^([ACEHJLMOPRSWXY][A-CEGHJ-NPR-TW-Z]|B[A-CEHJ-NPR-TW-Z]|G[ACEGHJ-NPR-TW-Z]|" +
       "[KT][A-CEGHJ-MPR-TW-Z]|N[A-CEGHJL-NPR-SW-Z]|Z[A-CEGHJ-NPR-TW-Y])[0-9]{6}[A-D ]?$"
 
-  def validate(nino: String): List[MtdError] = {
-    if (Nino.isValid(nino) && nino.matches(ninoRegex)) NoValidationErrors else List(NinoFormatError)
-  }
+  def validate(nino: String): List[MtdError] =
+    if (isValid(nino)) NoValidationErrors else List(NinoFormatError)
+
+  def isValid(nino: String): Boolean =
+    Nino.isValid(nino) && nino.matches(ninoRegex)
 
 }

--- a/app/api/models/errors/CommonMtdErrors.scala
+++ b/app/api/models/errors/CommonMtdErrors.scala
@@ -179,8 +179,12 @@ object BVRError                extends MtdError("BUSINESS_ERROR", "Business vali
 object ServiceUnavailableError extends MtdError("SERVICE_UNAVAILABLE", "Internal server error", INTERNAL_SERVER_ERROR)
 
 // Authorisation Errors
-object ClientNotAuthenticatedError extends MtdError("CLIENT_OR_AGENT_NOT_AUTHORISED", "The client and/or agent is not authorised", UNAUTHORIZED)
-object ClientNotAuthorisedError    extends MtdError("CLIENT_OR_AGENT_NOT_AUTHORISED", "The client and/or agent is not authorised", FORBIDDEN)
+
+// Authentication OK but not allowed access to the requested resource
+object ClientOrAgentNotAuthorisedError extends MtdError("CLIENT_OR_AGENT_NOT_AUTHORISED", "The client or agent is not authorised", FORBIDDEN){
+  def withStatus401: MtdError = copy(httpStatus = UNAUTHORIZED)
+}
+
 object InvalidBearerTokenError     extends MtdError("UNAUTHORIZED", "Bearer token is missing or not authorized", UNAUTHORIZED)
 
 // Accept header Errors

--- a/app/api/services/EnrolmentsAuthService.scala
+++ b/app/api/services/EnrolmentsAuthService.scala
@@ -17,7 +17,7 @@
 package api.services
 
 import api.models.auth.UserDetails
-import api.models.errors.{ClientNotAuthenticatedError, InternalError}
+import api.models.errors.{ClientOrAgentNotAuthorisedError, InternalError}
 import api.models.outcomes.AuthOutcome
 import config.AppConfig
 import uk.gov.hmrc.auth.core.AffinityGroup.{Agent, Individual, Organisation}
@@ -25,13 +25,11 @@ import uk.gov.hmrc.auth.core._
 import uk.gov.hmrc.auth.core.authorise.Predicate
 import uk.gov.hmrc.auth.core.retrieve.v2.Retrievals
 import uk.gov.hmrc.auth.core.retrieve.v2.Retrievals._
-import uk.gov.hmrc.auth.core.retrieve.~
 import uk.gov.hmrc.http.HeaderCarrier
 import utils.Logging
 
 import javax.inject.{Inject, Singleton}
 import scala.concurrent.{ExecutionContext, Future}
-
 @Singleton
 class EnrolmentsAuthService @Inject() (val connector: AuthConnector, val appConfig: AppConfig) extends Logging {
 
@@ -39,13 +37,7 @@ class EnrolmentsAuthService @Inject() (val connector: AuthConnector, val appConf
     override def authConnector: AuthConnector = connector
   }
 
-  def getAgentReferenceFromEnrolments(enrolments: Enrolments): Option[String] =
-    enrolments
-      .getEnrolment("HMRC-AS-AGENT")
-      .flatMap(_.getIdentifier("AgentReferenceNumber"))
-      .map(_.value)
-
-  def buildPredicate(predicate: Predicate): Predicate =
+  private def buildPredicate(predicate: Predicate): Predicate =
     if (appConfig.confidenceLevelConfig.authValidationEnabled) {
       predicate and ((Individual and ConfidenceLevel.L200) or Organisation or Agent)
     } else {
@@ -53,40 +45,43 @@ class EnrolmentsAuthService @Inject() (val connector: AuthConnector, val appConf
     }
 
   def authorised(predicate: Predicate)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[AuthOutcome] = {
-    authFunction.authorised(buildPredicate(predicate)).retrieve(affinityGroup and authorisedEnrolments) {
-      case Some(Individual) ~ _ =>
-        val user = UserDetails("", "Individual", None)
-        Future.successful(Right(user))
-      case Some(Organisation) ~ _ =>
-        val user = UserDetails("", "Organisation", None)
-        Future.successful(Right(user))
-      case Some(Agent) ~ _ =>
-        retrieveAgentDetails() map {
-          case arn @ Some(_) =>
-            val user: AuthOutcome = Right(UserDetails("", "Agent", arn))
-            user
-          case None =>
-            logger.warn(s"[EnrolmentsAuthService][authorised] No AgentReferenceNumber defined on agent enrolment.")
-            Left(InternalError)
-        }
-      case _ ~ _ =>
-        logger.warn(s"[EnrolmentsAuthService][authorised] Invalid AffinityGroup.")
-        Future.successful(Left(ClientNotAuthenticatedError))
-    } recoverWith {
-      case _: MissingBearerToken     => Future.successful(Left(ClientNotAuthenticatedError))
-      case _: AuthorisationException => Future.successful(Left(ClientNotAuthenticatedError))
-      case error =>
-        logger.warn(s"[EnrolmentsAuthService][authorised] An unexpected error occurred: $error")
-        Future.successful(Left(InternalError))
-    }
+    authFunction
+      .authorised(buildPredicate(predicate))
+      .retrieve(affinityGroup) {
+        case Some(Individual)   => Future.successful(Right(UserDetails("", "Individual", None)))
+        case Some(Organisation) => Future.successful(Right(UserDetails("", "Organisation", None)))
+        case Some(Agent) =>
+          retrieveAgentDetails().map {
+            case arn @ Some(_) => Right(UserDetails("", "Agent", arn))
+            case None =>
+              logger.warn(s"[EnrolmentsAuthService][authorised] No AgentReferenceNumber defined on agent enrolment.")
+              Left(InternalError)
+          }
+        case _ =>
+          logger.warn(s"[EnrolmentsAuthService][authorised] Invalid AffinityGroup.")
+          Future.successful(Left(ClientOrAgentNotAuthorisedError))
+      }
+      .recoverWith {
+        case _: MissingBearerToken     => Future.successful(Left(ClientOrAgentNotAuthorisedError))
+        case _: AuthorisationException => Future.successful(Left(ClientOrAgentNotAuthorisedError))
+        case error =>
+          logger.warn(s"[EnrolmentsAuthService][authorised] An unexpected error occurred: $error")
+          Future.successful(Left(InternalError))
+      }
   }
 
-  private def retrieveAgentDetails()(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Option[String]] =
+  private def retrieveAgentDetails()(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Option[String]] = {
+    def getAgentReferenceFrom(enrolments: Enrolments) =
+      enrolments
+        .getEnrolment("HMRC-AS-AGENT")
+        .flatMap(_.getIdentifier("AgentReferenceNumber"))
+        .map(_.value)
+
     authFunction
       .authorised(AffinityGroup.Agent and Enrolment("HMRC-AS-AGENT"))
-      .retrieve(Retrievals.agentCode and Retrievals.authorisedEnrolments) {
-        case _ ~ enrolments => Future.successful(getAgentReferenceFromEnrolments(enrolments))
-        case _              => Future.successful(None)
+      .retrieve(Retrievals.authorisedEnrolments) { enrolments =>
+        Future.successful(getAgentReferenceFrom(enrolments))
       }
+  }
 
 }

--- a/app/api/services/MtdIdLookupService.scala
+++ b/app/api/services/MtdIdLookupService.scala
@@ -16,22 +16,35 @@
 
 package api.services
 
-import api.connectors.{MtdIdLookupConnector, MtdIdLookupOutcome}
-import api.models.domain.Nino
-import api.models.errors.NinoFormatError
+import api.connectors.MtdIdLookupConnector
+import api.controllers.requestParsers.validators.validations.NinoValidation
+import api.models.errors.{ClientOrAgentNotAuthorisedError, InternalError, InvalidBearerTokenError, MtdError, NinoFormatError}
+import play.api.http.Status.{FORBIDDEN, UNAUTHORIZED}
 import uk.gov.hmrc.http.HeaderCarrier
 
 import javax.inject.{Inject, Singleton}
 import scala.concurrent.{ExecutionContext, Future}
 
+object MtdIdLookupService {
+  type Outcome = Either[MtdError, String]
+}
+
 @Singleton
 class MtdIdLookupService @Inject() (val connector: MtdIdLookupConnector) {
 
-  def lookup(nino: String)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[MtdIdLookupOutcome] = {
-    if (Nino.isValid(nino)) {
-      connector.getMtdId(nino)
-    } else {
+  def lookup(nino: String)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[MtdIdLookupService.Outcome] = {
+    if (!NinoValidation.isValid(nino)) {
       Future.successful(Left(NinoFormatError))
+    } else {
+      connector.getMtdId(nino) map {
+        case Right(mtdId) => Right(mtdId)
+        case Left(MtdIdLookupConnector.Error(statusCode)) =>
+          statusCode match {
+            case FORBIDDEN    => Left(ClientOrAgentNotAuthorisedError)
+            case UNAUTHORIZED => Left(InvalidBearerTokenError)
+            case _            => Left(InternalError)
+          }
+      }
     }
   }
 

--- a/app/utils/ErrorHandler.scala
+++ b/app/utils/ErrorHandler.scala
@@ -59,7 +59,7 @@ class ErrorHandler @Inject() (
         Future.successful(NotFound(NotFoundError.asJson))
       case _ =>
         val errorCode = statusCode match {
-          case UNAUTHORIZED           => ClientNotAuthenticatedError
+          case UNAUTHORIZED           => ClientOrAgentNotAuthorisedError.withStatus401
           case UNSUPPORTED_MEDIA_TYPE => InvalidBodyTypeError
           case _                      => MtdError("INVALID_REQUEST", message, BAD_REQUEST)
         }
@@ -84,7 +84,7 @@ class ErrorHandler @Inject() (
 
     val (status, errorCode, eventType) = ex match {
       case _: NotFoundException      => (NOT_FOUND, NotFoundError, "ResourceNotFound")
-      case _: AuthorisationException => (UNAUTHORIZED, ClientNotAuthenticatedError, "ClientError")
+      case _: AuthorisationException => (UNAUTHORIZED, ClientOrAgentNotAuthorisedError.withStatus401, "ClientError")
       case _: JsValidationException  => (BAD_REQUEST, BadRequestError, "ServerValidationError")
       case e: HttpException          => (e.responseCode, BadRequestError, "ServerValidationError")
       case e: UpstreamErrorResponse if UpstreamErrorResponse.Upstream4xxResponse.unapply(e).isDefined =>

--- a/build.sbt
+++ b/build.sbt
@@ -25,7 +25,7 @@ val appName = "individuals-income-received-api"
 lazy val ItTest = config("it") extend Test
 
 lazy val microservice = Project(appName, file("."))
-  .enablePlugins(play.sbt.PlayScala, SbtAutoBuildPlugin, SbtGitVersioning, SbtDistributablesPlugin)
+  .enablePlugins(play.sbt.PlayScala, SbtDistributablesPlugin)
   .disablePlugins(JUnitXmlReportPlugin) // Required to prevent https://github.com/scalatest/scalatest/issues/1427
   .settings(
     libraryDependencies ++= AppDependencies.compile ++ AppDependencies.test(),

--- a/conf/logback-test.xml
+++ b/conf/logback-test.xml
@@ -14,33 +14,12 @@
         </encoder>
     </appender>
 
-    <appender name="STDOUT_IGNORE_NETTY" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
-            <pattern>%date{ISO8601} level=[%level] logger=[%logger] thread=[%thread] rid=[not-available] user=[not-available] message=[%message] %replace(exception=[%xException]){'^exception=\[\]$',''}%n</pattern>
-        </encoder>
-    </appender>
-
-    <appender name="ACCESS_LOG_FILE" class="ch.qos.logback.core.FileAppender">
-        <file>logs/access.log</file>
-        <encoder>
-            <pattern>%message%n</pattern>
-        </encoder>
-    </appender>
-
     <appender name="CONNECTOR_LOG_FILE" class="ch.qos.logback.core.FileAppender">
         <file>logs/connector.log</file>
         <encoder>
             <pattern>%message%n</pattern>
         </encoder>
     </appender>
-
-    <logger name="accesslog" level="OFF" additivity="false">
-        <appender-ref ref="ACCESS_LOG_FILE" />
-    </logger>
-
-    <logger name="com.ning.http.client.providers.netty" additivity="false">
-        <appender-ref ref="STDOUT_IGNORE_NETTY" />
-    </logger>
 
     <logger name="com.google.inject" level="OFF"/>
 

--- a/conf/logback.xml
+++ b/conf/logback.xml
@@ -14,34 +14,12 @@
         </encoder>
     </appender>
 
-    <appender name="STDOUT_IGNORE_NETTY" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
-            <pattern>%date{ISO8601} level=[%level] logger=[%logger] thread=[%thread] rid=[not-available] user=[not-available] message=[%message] %replace(exception=[%xException]){'^exception=\[\]$',''}%n</pattern>
-        </encoder>
-    </appender>
-
-    <appender name="ACCESS_LOG_FILE" class="ch.qos.logback.core.FileAppender">
-        <file>logs/access.log</file>
-        <encoder>
-            <pattern>%message%n</pattern>
-        </encoder>
-    </appender>
-
     <appender name="CONNECTOR_LOG_FILE" class="ch.qos.logback.core.FileAppender">
         <file>logs/connector.log</file>
         <encoder>
             <pattern>%message%n</pattern>
         </encoder>
     </appender>
-
-
-    <logger name="accesslog" level="INFO" additivity="false">
-        <appender-ref ref="ACCESS_LOG_FILE" />
-    </logger>
-
-    <logger name="com.ning.http.client.providers.netty" additivity="false">
-        <appender-ref ref="STDOUT_IGNORE_NETTY" />
-    </logger>
 
     <logger name="com.google.inject" level="INFO"/>
 

--- a/it/api/stubs/AuthStub.scala
+++ b/it/api/stubs/AuthStub.scala
@@ -29,7 +29,7 @@ object AuthStub extends WireMockMethods {
     "key" -> "HMRC-MTD-IT",
     "identifiers" -> Json.arr(
       Json.obj(
-        "key"   -> "MTDITID",
+        "key" -> "MTDITID",
         "value" -> "1234567890"
       )
     )
@@ -40,7 +40,12 @@ object AuthStub extends WireMockMethods {
       .thenReturn(status = OK, body = successfulAuthResponse(mtdEnrolment))
   }
 
+  private def successfulAuthResponse(enrolments: JsObject*): JsObject = {
+    Json.obj("authorisedEnrolments" -> enrolments, "affinityGroup" -> "Individual")
+  }
+
   def unauthorisedNotLoggedIn(): StubMapping = {
+    // Note that MissingBearerToken extends NoActiveSession
     when(method = POST, uri = authoriseUri)
       .thenReturn(status = UNAUTHORIZED, headers = Map("WWW-Authenticate" -> """MDTP detail="MissingBearerToken""""))
   }
@@ -49,9 +54,4 @@ object AuthStub extends WireMockMethods {
     when(method = POST, uri = authoriseUri)
       .thenReturn(status = UNAUTHORIZED, headers = Map("WWW-Authenticate" -> """MDTP detail="InvalidBearerToken""""))
   }
-
-  private def successfulAuthResponse(enrolments: JsObject*): JsObject = {
-    Json.obj("authorisedEnrolments" -> enrolments, "affinityGroup" -> "Individual")
-  }
-
 }

--- a/it/api/stubs/MtdIdLookupStub.scala
+++ b/it/api/stubs/MtdIdLookupStub.scala
@@ -25,24 +25,12 @@ object MtdIdLookupStub extends WireMockMethods {
 
   private def lookupUrl(nino: String): String = s"/mtd-identifier-lookup/nino/$nino"
 
-  def ninoFound(nino: String): StubMapping = {
+  def ninoFound(nino: String): StubMapping =
     when(method = GET, uri = lookupUrl(nino))
       .thenReturn(status = OK, body = Json.obj("mtdbsa" -> "12345678"))
-  }
 
-  def unauthorised(nino: String): StubMapping = {
+  def error(nino: String, status: Int): StubMapping =
     when(method = GET, uri = lookupUrl(nino))
-      .thenReturn(status = FORBIDDEN, body = Json.obj())
-  }
-
-  def badRequest(nino: String): StubMapping = {
-    when(method = GET, uri = lookupUrl(nino))
-      .thenReturn(status = BAD_REQUEST, body = Json.obj())
-  }
-
-  def internalServerError(nino: String): StubMapping = {
-    when(method = GET, uri = lookupUrl(nino))
-      .thenReturn(status = INTERNAL_SERVER_ERROR, body = Json.obj())
-  }
+      .thenReturn(status, body = Json.obj())
 
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -18,7 +18,7 @@ resolvers += "Typesafe Releases" at "https://repo.typesafe.com/typesafe/releases
 resolvers += "HMRC-open-artefacts-maven" at "https://open.artefacts.tax.service.gov.uk/maven2"
 resolvers += Resolver.url("HMRC-open-artefacts-ivy", url("https://open.artefacts.tax.service.gov.uk/ivy2"))(Resolver.ivyStylePatterns)
 
-addSbtPlugin("uk.gov.hmrc"   % "sbt-auto-build"     % "3.21.0")
+addSbtPlugin("uk.gov.hmrc"   % "sbt-auto-build"     % "3.22.0")
 addSbtPlugin("uk.gov.hmrc"   % "sbt-distributables" % "2.5.0")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt"       % "2.4.6")
 

--- a/test/api/connectors/MtdIdLookupConnectorSpec.scala
+++ b/test/api/connectors/MtdIdLookupConnectorSpec.scala
@@ -17,12 +17,14 @@
 package api.connectors
 
 import api.mocks.MockHttpClient
-import api.models.errors.InternalError
 import mocks.MockAppConfig
 
 import scala.concurrent.Future
 
 class MtdIdLookupConnectorSpec extends ConnectorSpec {
+
+  val nino  = "test-nino"
+  val mtdId = "test-mtdId"
 
   class Test extends MockHttpClient with MockAppConfig {
 
@@ -34,29 +36,29 @@ class MtdIdLookupConnectorSpec extends ConnectorSpec {
     MockedAppConfig.mtdIdBaseUrl returns baseUrl
   }
 
-  val nino  = "test-nino"
-  val mtdId = "test-mtdId"
-
   "getMtdId" should {
     "return an MtdId" when {
       "the http client returns a mtd id" in new Test {
         MockedHttpClient
-          .get[MtdIdLookupOutcome](s"$baseUrl/mtd-identifier-lookup/nino/$nino", config = dummyDesHeaderCarrierConfig)
+          .get[MtdIdLookupConnector.Outcome](s"$baseUrl/mtd-identifier-lookup/nino/$nino", dummyHeaderCarrierConfig)
           .returns(Future.successful(Right(mtdId)))
 
-        val result: MtdIdLookupOutcome = await(connector.getMtdId(nino))
-        result shouldBe Right(mtdId)
+        await(connector.getMtdId(nino)) shouldBe Right(mtdId)
       }
     }
 
-    "return a DownstreamError" when {
-      "the http client returns a DownstreamError" in new Test {
-        MockedHttpClient
-          .get[MtdIdLookupOutcome](s"$baseUrl/mtd-identifier-lookup/nino/$nino", config = dummyDesHeaderCarrierConfig)
-          .returns(Future.successful(Left(InternalError)))
+    "return an error" when {
+      "the http client returns that error" in new Test {
+        val statusCode: Int = IM_A_TEAPOT
 
-        val result: MtdIdLookupOutcome = await(connector.getMtdId(nino))
-        result shouldBe Left(InternalError)
+        MockedHttpClient
+          .get[MtdIdLookupConnector.Outcome](
+            url = s"$baseUrl/mtd-identifier-lookup/nino/$nino",
+            config = dummyHeaderCarrierConfig
+          )
+          .returns(Future.successful(Left(MtdIdLookupConnector.Error(statusCode))))
+
+        await(connector.getMtdId(nino)) shouldBe Left(MtdIdLookupConnector.Error(statusCode))
       }
     }
   }

--- a/test/api/connectors/httpparsers/MtdIdLookupHttpParserSpec.scala
+++ b/test/api/connectors/httpparsers/MtdIdLookupHttpParserSpec.scala
@@ -16,81 +16,46 @@
 
 package api.connectors.httpparsers
 
-import api.connectors.MtdIdLookupOutcome
+import api.connectors.MtdIdLookupConnector
 import api.connectors.httpparsers.MtdIdLookupHttpParser.mtdIdLookupHttpReads
-import api.models.errors.{InternalError, InvalidBearerTokenError, NinoFormatError}
+import play.api.http.Status.IM_A_TEAPOT
 import play.api.libs.json.Writes.StringWrites
-import play.api.libs.json.{JsObject, Json}
-import play.api.test.Helpers.{FORBIDDEN, INTERNAL_SERVER_ERROR, OK, UNAUTHORIZED}
+import play.api.libs.json.{JsResultException, Json}
+import play.api.test.Helpers.OK
 import support.UnitSpec
 import uk.gov.hmrc.http.HttpResponse
 
 class MtdIdLookupHttpParserSpec extends UnitSpec {
 
-  val method = "GET"
-  val url    = "test-url"
-  val mtdId  = "test-mtd-id"
+  private val method = "GET"
+  private val url    = "test-url"
 
-  val mtdIdJson: JsObject   = Json.obj("mtdbsa" -> mtdId)
-  val invalidJson: JsObject = Json.obj("hello" -> "world")
+  "read" when {
+    "the response contains a 200 status" when {
+      "the response body contains an MtdId" must {
+        "return the MtdId" in {
+          val mtdId    = "test-mtd-id"
+          val response = HttpResponse(OK, Json.obj("mtdbsa" -> mtdId), Map.empty[String, Seq[String]])
 
-  "read" should {
-    "return an MtdId" when {
-      "the HttpResponse contains a 200 status and a correct response body" in {
-        val response                   = HttpResponse(OK, mtdIdJson.toString())
-        val result: MtdIdLookupOutcome = mtdIdLookupHttpReads.read(method, url, response)
+          mtdIdLookupHttpReads.read(method, url, response) shouldBe Right(mtdId)
+        }
+      }
 
-        result shouldBe Right(mtdId)
+      "the response body is not valid" must {
+        "throw an JsResultException" in {
+          val response = HttpResponse(OK, Json.obj("hello" -> "world"), Map.empty[String, Seq[String]])
+
+          intercept[JsResultException](mtdIdLookupHttpReads.read(method, url, response))
+        }
       }
     }
 
-    "returns an downstream error" when {
-      "backend doesn't have a valid data" in {
-        val response                   = HttpResponse(OK, invalidJson.toString())
-        val result: MtdIdLookupOutcome = mtdIdLookupHttpReads.read(method, url, response)
+    "the response contains a non-200 status" must {
+      "return the status code as an error" in {
+        val status   = IM_A_TEAPOT
+        val response = HttpResponse(status, "ignored")
 
-        result shouldBe Left(InternalError)
-      }
-
-      "backend doesn't return any data" in {
-        val response                   = HttpResponse(OK, None.orNull)
-        val result: MtdIdLookupOutcome = mtdIdLookupHttpReads.read(method, url, response)
-
-        result shouldBe Left(InternalError)
-      }
-
-      "the json cannot be read" in {
-        val response                   = HttpResponse(OK, None.orNull)
-        val result: MtdIdLookupOutcome = mtdIdLookupHttpReads.read(method, url, response)
-
-        result shouldBe Left(InternalError)
-      }
-    }
-
-    "return an InvalidNino error" when {
-      "the HttpResponse contains a 403 status" in {
-        val response                   = HttpResponse(FORBIDDEN, None.orNull)
-        val result: MtdIdLookupOutcome = mtdIdLookupHttpReads.read(method, url, response)
-
-        result shouldBe Left(NinoFormatError)
-      }
-    }
-
-    "return an Unauthorised error" when {
-      "the HttpResponse contains a 403 status" in {
-        val response                   = HttpResponse(UNAUTHORIZED, None.orNull)
-        val result: MtdIdLookupOutcome = mtdIdLookupHttpReads.read(method, url, response)
-
-        result shouldBe Left(InvalidBearerTokenError)
-      }
-    }
-
-    "return a DownstreamError" when {
-      "the HttpResponse contains any other status" in {
-        val response                   = HttpResponse(INTERNAL_SERVER_ERROR, None.orNull)
-        val result: MtdIdLookupOutcome = mtdIdLookupHttpReads.read(method, url, response)
-
-        result shouldBe Left(InternalError)
+        mtdIdLookupHttpReads.read(method, url, response) shouldBe Left(MtdIdLookupConnector.Error(status))
       }
     }
   }

--- a/test/api/controllers/AuthorisedControllerSpec.scala
+++ b/test/api/controllers/AuthorisedControllerSpec.scala
@@ -17,10 +17,10 @@
 package api.controllers
 
 import api.mocks.services.{MockEnrolmentsAuthService, MockMtdIdLookupService}
-import api.models.errors.{ClientNotAuthenticatedError, ClientNotAuthorisedError, InternalError, InvalidBearerTokenError, NinoFormatError}
+import api.models.errors.MtdError
 import api.services.{EnrolmentsAuthService, MtdIdLookupService}
 import play.api.libs.json.Json
-import play.api.mvc.{Action, AnyContent}
+import play.api.mvc.{Action, AnyContent, Result}
 import uk.gov.hmrc.auth.core.Enrolment
 import uk.gov.hmrc.auth.core.authorise.Predicate
 import uk.gov.hmrc.http.HeaderCarrier
@@ -30,8 +30,54 @@ import scala.concurrent.Future
 
 class AuthorisedControllerSpec extends ControllerBaseSpec {
 
+  private val nino = "AA123456A"
+
+  private val mtdId     = "X123567890"
+  private val someError = MtdError("SOME_CODE", "A message", IM_A_TEAPOT)
+
+  private val predicate: Predicate = Enrolment("HMRC-MTD-IT")
+    .withIdentifier("MTDITID", mtdId)
+    .withDelegatedAuthRule("mtd-it-auth")
+
+  "calling an action" when {
+
+    "the user is authorised" should {
+      "return a 200" in new Test {
+        MockedMtdIdLookupService.lookup(nino) returns Future.successful(Right(mtdId))
+
+        MockedEnrolmentsAuthService.authoriseUser()
+
+        private val result = target.action(nino)(fakeGetRequest)
+        status(result) shouldBe OK
+      }
+    }
+
+    "the EnrolmentsAuthService returns an error" should {
+      "return that error (with its status code)" in new Test {
+        MockedMtdIdLookupService.lookup(nino) returns Future.successful(Right(mtdId))
+
+        MockedEnrolmentsAuthService.authorised(predicate) returns Future.successful(Left(someError))
+
+        val result: Future[Result] = target.action(nino)(fakeGetRequest)
+        status(result) shouldBe someError.httpStatus
+        contentAsJson(result) shouldBe Json.toJson(someError)
+      }
+    }
+
+    "the MtdIdLookupService returns an error" should {
+      "return that error (with its status code)" in new Test {
+        MockedMtdIdLookupService.lookup(nino) returns Future.successful(Left(someError))
+
+        val result: Future[Result] = target.action(nino)(fakeGetRequest)
+        status(result) shouldBe someError.httpStatus
+        contentAsJson(result) shouldBe Json.toJson(someError)
+      }
+    }
+  }
+
   trait Test extends MockEnrolmentsAuthService with MockMtdIdLookupService {
-    val hc = HeaderCarrier()
+
+    val hc: HeaderCarrier = HeaderCarrier()
 
     class TestController extends AuthorisedController(cc) {
       override val authService: EnrolmentsAuthService = mockEnrolmentsAuthService
@@ -44,126 +90,6 @@ class AuthorisedControllerSpec extends ControllerBaseSpec {
     }
 
     lazy val target = new TestController()
-  }
-
-  val nino  = "AA123456A"
-  val mtdId = "X123567890"
-
-  val predicate: Predicate = Enrolment("HMRC-MTD-IT")
-    .withIdentifier("MTDITID", mtdId)
-    .withDelegatedAuthRule("mtd-it-auth")
-
-  "calling an action" when {
-    "the user is authorised" should {
-      "return a 200" in new Test {
-
-        MockedMtdIdLookupService
-          .lookup(nino)
-          .returns(Future.successful(Right(mtdId)))
-
-        MockedEnrolmentsAuthService.authoriseUser()
-
-        private val result = target.action(nino)(fakeGetRequest)
-        status(result) shouldBe OK
-      }
-    }
-
-    "auth returns an unexpected error" should {
-      "return a 500" in new Test {
-
-        MockedMtdIdLookupService
-          .lookup(nino)
-          .returns(Future.successful(Right(mtdId)))
-
-        MockedEnrolmentsAuthService
-          .authorised(predicate)
-          .returns(Future.successful(Left(InternalError)))
-
-        private val result = target.action(nino)(fakeGetRequest)
-        status(result) shouldBe INTERNAL_SERVER_ERROR
-      }
-    }
-
-    "the nino is invalid" should {
-      "return a 400" in new Test {
-
-        MockedMtdIdLookupService
-          .lookup(nino)
-          .returns(Future.successful(Left(NinoFormatError)))
-
-        private val result = target.action(nino)(fakeGetRequest)
-        status(result) shouldBe BAD_REQUEST
-      }
-    }
-
-    "the nino is valid but invalid bearer token" should {
-      "return a 401" in new Test {
-
-        MockedMtdIdLookupService
-          .lookup(nino)
-          .returns(Future.successful(Left(InvalidBearerTokenError)))
-
-        private val result = target.action(nino)(fakeGetRequest)
-        status(result) shouldBe UNAUTHORIZED
-      }
-    }
-
-  }
-
-  "authorisation checks fail when retrieving the MDT ID" should {
-    "return a 403" in new Test {
-
-      MockedMtdIdLookupService
-        .lookup(nino)
-        .returns(Future.successful(Left(ClientNotAuthorisedError)))
-
-      private val result = target.action(nino)(fakeGetRequest)
-      status(result) shouldBe FORBIDDEN
-    }
-  }
-
-  "the an error occurs retrieving the MDT ID" should {
-    "return a 500" in new Test {
-
-      MockedMtdIdLookupService
-        .lookup(nino)
-        .returns(Future.successful(Left(InternalError)))
-
-      private val result = target.action(nino)(fakeGetRequest)
-      status(result) shouldBe INTERNAL_SERVER_ERROR
-    }
-  }
-
-  "the MTD user is not authenticated" should {
-    "return a 401" in new Test {
-
-      MockedMtdIdLookupService
-        .lookup(nino)
-        .returns(Future.successful(Right(mtdId)))
-
-      MockedEnrolmentsAuthService
-        .authorised(predicate)
-        .returns(Future.successful(Left(ClientNotAuthenticatedError)))
-
-      private val result = target.action(nino)(fakeGetRequest)
-      status(result) shouldBe FORBIDDEN
-    }
-  }
-
-  "the MTD user is not authorised" should {
-    "return a 403" in new Test {
-
-      MockedMtdIdLookupService
-        .lookup(nino)
-        .returns(Future.successful(Right(mtdId)))
-
-      MockedEnrolmentsAuthService
-        .authorised(predicate)
-        .returns(Future.successful(Left(ClientNotAuthenticatedError)))
-
-      private val result = target.action(nino)(fakeGetRequest)
-      status(result) shouldBe FORBIDDEN
-    }
   }
 
 }

--- a/test/api/controllers/requestParsers/validators/validations/NinoValidationSpec.scala
+++ b/test/api/controllers/requestParsers/validators/validations/NinoValidationSpec.scala
@@ -22,29 +22,30 @@ import support.UnitSpec
 
 class NinoValidationSpec extends UnitSpec with JsonErrorValidators {
 
-  "validate" should {
-    "return no errors" when {
-      "when a valid NINO is supplied" in {
+  "NinoValidation" when {
+    "a valid NINO is supplied" must {
+      val nino = "AA123456A"
 
-        val validNino        = "AA123456A"
-        val validationResult = NinoValidation.validate(validNino)
-        validationResult.isEmpty shouldBe true
+      "be valid" in {
+        NinoValidation.isValid(nino) shouldBe true
+      }
 
+      "return no errors" in {
+        NinoValidation.validate(nino) shouldBe empty
       }
     }
 
-    "return an error" when {
-      "when an invalid NINO is supplied" in {
+    "a invalid NINO is supplied" must {
+      val nino = "AA123456ABCBBCBCBC"
 
-        val invalidNino      = "AA123456ABCBBCBCBC"
-        val validationResult = NinoValidation.validate(invalidNino)
-        validationResult.isEmpty shouldBe false
-        validationResult.length shouldBe 1
-        validationResult.head shouldBe NinoFormatError
+      "not be valid" in {
+        NinoValidation.isValid(nino) shouldBe false
+      }
 
+      "return a NinoFormatError" in {
+        NinoValidation.validate(nino) shouldBe List(NinoFormatError)
       }
     }
-
   }
 
 }

--- a/test/api/mocks/connectors/MockMtdIdLookupConnector.scala
+++ b/test/api/mocks/connectors/MockMtdIdLookupConnector.scala
@@ -16,7 +16,7 @@
 
 package api.mocks.connectors
 
-import api.connectors.{MtdIdLookupConnector, MtdIdLookupOutcome}
+import api.connectors.MtdIdLookupConnector
 import org.scalamock.handlers.CallHandler
 import org.scalamock.scalatest.MockFactory
 import uk.gov.hmrc.http.HeaderCarrier
@@ -29,7 +29,7 @@ trait MockMtdIdLookupConnector extends MockFactory {
 
   object MockedMtdIdLookupConnector {
 
-    def lookup(nino: String): CallHandler[Future[MtdIdLookupOutcome]] = {
+    def lookup(nino: String): CallHandler[Future[MtdIdLookupConnector.Outcome]] = {
       (mockMtdIdLookupConnector
         .getMtdId(_: String)(_: HeaderCarrier, _: ExecutionContext))
         .expects(nino, *, *)

--- a/test/api/mocks/services/MockMtdIdLookupService.scala
+++ b/test/api/mocks/services/MockMtdIdLookupService.scala
@@ -16,7 +16,6 @@
 
 package api.mocks.services
 
-import api.connectors.MtdIdLookupOutcome
 import api.services.MtdIdLookupService
 import org.scalamock.handlers.CallHandler
 import org.scalamock.scalatest.MockFactory
@@ -30,7 +29,7 @@ trait MockMtdIdLookupService extends MockFactory {
 
   object MockedMtdIdLookupService {
 
-    def lookup(nino: String): CallHandler[Future[MtdIdLookupOutcome]] = {
+    def lookup(nino: String): CallHandler[Future[MtdIdLookupService.Outcome]] = {
       (mockMtdIdLookupService
         .lookup(_: String)(_: HeaderCarrier, _: ExecutionContext))
         .expects(nino, *, *)

--- a/test/api/services/EnrolmentsAuthServiceSpec.scala
+++ b/test/api/services/EnrolmentsAuthServiceSpec.scala
@@ -17,233 +17,146 @@
 package api.services
 
 import api.models.auth.UserDetails
-import api.models.errors.{ClientNotAuthenticatedError, InternalError}
+import api.models.errors.{ClientOrAgentNotAuthorisedError, InternalError}
 import config.ConfidenceLevelConfig
 import mocks.MockAppConfig
 import org.scalamock.handlers.CallHandler
 import uk.gov.hmrc.auth.core._
-import uk.gov.hmrc.auth.core.authorise.{AlternatePredicate, CompositePredicate, EmptyPredicate, Predicate}
+import uk.gov.hmrc.auth.core.authorise.{EmptyPredicate, Predicate}
+import uk.gov.hmrc.auth.core.retrieve.Retrieval
 import uk.gov.hmrc.auth.core.retrieve.v2.Retrievals._
-import uk.gov.hmrc.auth.core.retrieve.{Retrieval, ~}
 import uk.gov.hmrc.http.HeaderCarrier
 
 import scala.concurrent.{ExecutionContext, Future}
 
 class EnrolmentsAuthServiceSpec extends ServiceSpec with MockAppConfig {
 
-  private val extraPredicatesAnd =
-    CompositePredicate(
-      _,
-      AlternatePredicate(
-        AlternatePredicate(CompositePredicate(AffinityGroup.Individual, ConfidenceLevel.L200), AffinityGroup.Organisation),
-        AffinityGroup.Agent)
-    )
+  private def extraPredicatesAnd(predicate: Predicate) = predicate and
+    ((AffinityGroup.Individual and ConfidenceLevel.L200) or AffinityGroup.Organisation or AffinityGroup.Agent)
 
-  "calling .buildPredicate" when {
+  "calling .authorised" when {
+    val inputPredicate = EmptyPredicate
+
     "confidence level checks are on" should {
-      "return a Predicate containing confidence level 200 on top of the provided Predicate" when {
-        "passed a simple Individual Predicate" in new Test {
-          mockConfidenceLevelCheckConfig()
-
-          target.buildPredicate(AffinityGroup.Individual) shouldBe extraPredicatesAnd(AffinityGroup.Individual)
-        }
-        "passed a complex Individual Predicate" in new Test {
-          mockConfidenceLevelCheckConfig()
-
-          target.buildPredicate(CompositePredicate(AffinityGroup.Individual, EmptyPredicate)) shouldBe {
-            extraPredicatesAnd(CompositePredicate(AffinityGroup.Individual, EmptyPredicate))
-          }
-        }
-      }
-      "return a Predicate containing only the provided Predicate" when {
-        "passed a simple Organisation Predicate" in new Test {
-          mockConfidenceLevelCheckConfig()
-
-          target.buildPredicate(AffinityGroup.Organisation) shouldBe extraPredicatesAnd(AffinityGroup.Organisation)
-        }
-        "passed a complex Organisation Predicate" in new Test {
-          mockConfidenceLevelCheckConfig()
-
-          target.buildPredicate(CompositePredicate(AffinityGroup.Organisation, EmptyPredicate)) shouldBe {
-            extraPredicatesAnd(CompositePredicate(AffinityGroup.Organisation, EmptyPredicate))
-          }
-        }
-        "passed a simple Agent Predicate" in new Test {
-          mockConfidenceLevelCheckConfig()
-
-          target.buildPredicate(AffinityGroup.Agent) shouldBe extraPredicatesAnd(AffinityGroup.Agent)
-        }
-        "passed a complex Agent Predicate" in new Test {
-          mockConfidenceLevelCheckConfig()
-
-          target.buildPredicate(CompositePredicate(AffinityGroup.Agent, EmptyPredicate)) shouldBe {
-            extraPredicatesAnd(CompositePredicate(AffinityGroup.Agent, EmptyPredicate))
-          }
-        }
-      }
+      behave like authService(authValidationEnabled = true, extraPredicatesAnd(inputPredicate))
     }
 
     "confidence level checks are off" should {
-      "return a Predicate containing only the provided Predicate" when {
-        "passed a simple Predicate" in new Test {
-          mockConfidenceLevelCheckConfig(authValidationEnabled = false)
-
-          target.buildPredicate(AffinityGroup.Individual) shouldBe AffinityGroup.Individual
-        }
-        "passed a complex Predicate" in new Test {
-          mockConfidenceLevelCheckConfig(authValidationEnabled = false)
-
-          target.buildPredicate(CompositePredicate(AffinityGroup.Agent, Enrolment("HMRC-AS-AGENT"))) shouldBe
-            CompositePredicate(AffinityGroup.Agent, Enrolment("HMRC-AS-AGENT"))
-        }
-      }
+      behave like authService(authValidationEnabled = false, inputPredicate)
     }
-  }
 
-  "calling .authorised" when {
-    "confidence level checks are on" should {
-      "return user details" in new Test {
-        mockConfidenceLevelCheckConfig()
+    def authService(authValidationEnabled: Boolean, expectedPredicate: Predicate): Unit = {
+      behave like authorisedIndividual(inputPredicate, authValidationEnabled, expectedPredicate)
+      behave like authorisedOrganisation(inputPredicate, authValidationEnabled, expectedPredicate)
 
-        val retrievalsResult = new ~(Some(AffinityGroup.Individual), Enrolments(Set.empty))
-        val expected         = Right(UserDetails("", "Individual", None))
+      behave like authorisedAgentsMissingArn(inputPredicate, authValidationEnabled, expectedPredicate)
+      behave like authorisedAgents(inputPredicate, authValidationEnabled, expectedPredicate)
+
+      behave like disallowUsersWithoutEnrolments(inputPredicate, authValidationEnabled, expectedPredicate)
+      behave like disallowWhenNotLoggedIn(inputPredicate, authValidationEnabled, expectedPredicate)
+    }
+
+    def authorisedIndividual(inputPredicate: Predicate, authValidationEnabled: Boolean, expectedPredicate: Predicate): Unit =
+      "allow authorised individuals" in new Test {
+        mockConfidenceLevelCheckConfig(authValidationEnabled = authValidationEnabled)
 
         MockedAuthConnector
-          .authorised(extraPredicatesAnd(EmptyPredicate), authRetrievals)
-          .returns(Future.successful(retrievalsResult))
+          .authorised(expectedPredicate, affinityGroup)
+          .returns(Future.successful(Some(AffinityGroup.Individual)))
 
-        private val result = await(target.authorised(EmptyPredicate))
-
-        result shouldBe expected
+        await(target.authorised(inputPredicate)) shouldBe Right(UserDetails("", "Individual", None))
       }
-    }
 
-    "the user is an authorised individual" should {
-      "return the 'Individual' user type in the user details" in new Test {
-
-        mockConfidenceLevelCheckConfig(authValidationEnabled = false)
-
-        val retrievalsResult = new ~(Some(AffinityGroup.Individual), Enrolments(Set.empty))
-        val expected         = Right(UserDetails("", "Individual", None))
+    def authorisedOrganisation(inputPredicate: Predicate, authValidationEnabled: Boolean, expectedPredicate: Predicate): Unit =
+      "allow authorised organisations" in new Test {
+        mockConfidenceLevelCheckConfig(authValidationEnabled = authValidationEnabled)
 
         MockedAuthConnector
-          .authorised(EmptyPredicate, authRetrievals)
-          .returns(Future.successful(retrievalsResult))
+          .authorised(expectedPredicate, affinityGroup)
+          .returns(Future.successful(Some(AffinityGroup.Organisation)))
 
-        private val result = await(target.authorised(EmptyPredicate))
-
-        result shouldBe expected
+        await(target.authorised(inputPredicate)) shouldBe Right(UserDetails("", "Organisation", None))
       }
-    }
 
-    "the user is an authorised organisation" should {
-      "return the 'Organisation' user type in the user details" in new Test {
-
-        mockConfidenceLevelCheckConfig(authValidationEnabled = false)
-
-        val retrievalsResult = new ~(Some(AffinityGroup.Organisation), Enrolments(Set.empty))
-        val expected         = Right(UserDetails("", "Organisation", None))
-
-        MockedAuthConnector
-          .authorised(EmptyPredicate, authRetrievals)
-          .returns(Future.successful(retrievalsResult))
-
-        private val result = await(target.authorised(EmptyPredicate))
-
-        result shouldBe expected
-      }
-    }
-
-    "the user is an agent with missing ARN" should {
-      val arn = "123567890"
-      val incompleteEnrolments = Enrolments(
-        Set(
-          Enrolment(
-            "HMRC-AS-AGENT",
-            Seq(EnrolmentIdentifier("SomeOtherIdentifier", arn)),
-            "Active"
+    def authorisedAgentsMissingArn(inputPredicate: Predicate, authValidationEnabled: Boolean, expectedPredicate: Predicate): Unit = {
+      "disallow agents that are missing an ARN" in new Test {
+        val enrolmentsWithoutArn: Enrolments = Enrolments(
+          Set(
+            Enrolment(
+              "HMRC-AS-AGENT",
+              Seq(EnrolmentIdentifier("SomeOtherIdentifier", "123567890")),
+              "Active"
+            )
           )
         )
-      )
 
-      val retrievalsResult = new ~(Some(AffinityGroup.Agent), incompleteEnrolments)
-
-      "return an error" in new Test {
-
-        mockConfidenceLevelCheckConfig(authValidationEnabled = false)
-
-        val expected = Left(InternalError)
+        mockConfidenceLevelCheckConfig(authValidationEnabled = authValidationEnabled)
 
         MockedAuthConnector
-          .authorised(EmptyPredicate, authRetrievals)
-          .returns(Future.successful(retrievalsResult))
+          .authorised(expectedPredicate, affinityGroup)
+          .returns(Future.successful(Some(AffinityGroup.Agent)))
 
-        private val result = await(target.authorised(EmptyPredicate))
+        MockedAuthConnector
+          .authorised(AffinityGroup.Agent and Enrolment("HMRC-AS-AGENT"), authorisedEnrolments)
+          .returns(Future.successful(enrolmentsWithoutArn))
 
-        result shouldBe expected
+        await(target.authorised(inputPredicate)) shouldBe Left(InternalError)
       }
     }
 
-    "the user is not logged in" should {
-      "return an unauthenticated error" in new Test {
+    def authorisedAgents(inputPredicate: Predicate, authValidationEnabled: Boolean, expectedPredicate: Predicate): Unit =
+      "allow authorised agents with ARN" in new Test {
+        val arn = "123567890"
+        val enrolmentsWithArn: Enrolments = Enrolments(
+          Set(
+            Enrolment(
+              "HMRC-AS-AGENT",
+              Seq(EnrolmentIdentifier("AgentReferenceNumber", arn)),
+              "Active"
+            )
+          )
+        )
 
-        mockConfidenceLevelCheckConfig(authValidationEnabled = false)
-
-        val expected = Left(ClientNotAuthenticatedError)
+        mockConfidenceLevelCheckConfig(authValidationEnabled = authValidationEnabled)
 
         MockedAuthConnector
-          .authorised(EmptyPredicate, authRetrievals)
+          .authorised(expectedPredicate, affinityGroup)
+          .returns(Future.successful(Some(AffinityGroup.Agent)))
+
+        MockedAuthConnector
+          .authorised(AffinityGroup.Agent and Enrolment("HMRC-AS-AGENT"), authorisedEnrolments)
+          .returns(Future.successful(enrolmentsWithArn))
+
+        await(target.authorised(inputPredicate)) shouldBe Right(UserDetails("", "Agent", Some(arn)))
+
+      }
+
+    def disallowWhenNotLoggedIn(inputPredicate: Predicate, authValidationEnabled: Boolean, expectedPredicate: Predicate): Unit =
+      "disallow users that are not logged in" in new Test {
+        mockConfidenceLevelCheckConfig(authValidationEnabled = authValidationEnabled)
+
+        MockedAuthConnector
+          .authorised(expectedPredicate, affinityGroup)
           .returns(Future.failed(MissingBearerToken()))
 
-        private val result = await(target.authorised(EmptyPredicate))
-
-        result shouldBe expected
+        await(target.authorised(inputPredicate)) shouldBe Left(ClientOrAgentNotAuthorisedError)
       }
-    }
 
-    "the user is not authorised" should {
-      "return an unauthorised error" in new Test {
-
-        mockConfidenceLevelCheckConfig(authValidationEnabled = false)
-
-        val expected = Left(ClientNotAuthenticatedError)
+    def disallowUsersWithoutEnrolments(inputPredicate: Predicate, authValidationEnabled: Boolean, expectedPredicate: Predicate): Unit =
+      "disallow users without enrolments" in new Test {
+        mockConfidenceLevelCheckConfig(authValidationEnabled = authValidationEnabled)
 
         MockedAuthConnector
-          .authorised(EmptyPredicate, authRetrievals)
+          .authorised(expectedPredicate, affinityGroup)
           .returns(Future.failed(InsufficientEnrolments()))
 
-        private val result = await(target.authorised(EmptyPredicate))
-
-        result shouldBe expected
+        await(target.authorised(inputPredicate)) shouldBe Left(ClientOrAgentNotAuthorisedError)
       }
-    }
-
-    "calling getAgentReferenceFromEnrolments" should {
-      "return a valid AgentReferenceNumber" when {
-        "a valid agent Enrolment is supplied" in new Test {
-          val expectedArn = "123567890"
-          val actualArn: Option[String] = target.getAgentReferenceFromEnrolments(
-            Enrolments(
-              Set(
-                Enrolment(
-                  "HMRC-AS-AGENT",
-                  Seq(EnrolmentIdentifier("AgentReferenceNumber", expectedArn)),
-                  "Active"
-                )
-              )
-            ))
-
-          actualArn shouldBe Some(expectedArn)
-        }
-      }
-    }
-
   }
 
   trait Test {
     val mockAuthConnector: AuthConnector = mock[AuthConnector]
-
-    val authRetrievals: Retrieval[Option[AffinityGroup] ~ Enrolments] = affinityGroup and authorisedEnrolments
+    lazy val target                      = new EnrolmentsAuthService(mockAuthConnector, mockAppConfig)
 
     object MockedAuthConnector {
 
@@ -255,12 +168,10 @@ class EnrolmentsAuthServiceSpec extends ServiceSpec with MockAppConfig {
 
     }
 
-    lazy val target = new EnrolmentsAuthService(mockAuthConnector, mockAppConfig)
-
-    def mockConfidenceLevelCheckConfig(authValidationEnabled: Boolean = true, confidenceLevel: ConfidenceLevel = ConfidenceLevel.L200): Unit = {
-      MockedAppConfig.confidenceLevelCheckEnabled.returns(
+    def mockConfidenceLevelCheckConfig(authValidationEnabled: Boolean): Unit = {
+      MockedAppConfig.confidenceLevelConfig.returns(
         ConfidenceLevelConfig(
-          confidenceLevel = confidenceLevel,
+          confidenceLevel = ConfidenceLevel.L200,
           definitionEnabled = true,
           authValidationEnabled = authValidationEnabled
         )

--- a/test/api/services/MtdIdLookupServiceSpec.scala
+++ b/test/api/services/MtdIdLookupServiceSpec.scala
@@ -16,63 +16,61 @@
 
 package api.services
 
+import api.connectors.MtdIdLookupConnector
 import api.mocks.connectors.MockMtdIdLookupConnector
-import api.models.errors.{ClientNotAuthenticatedError, InternalError, MtdError, NinoFormatError}
+import api.models.errors.{ClientOrAgentNotAuthorisedError, InternalError, InvalidBearerTokenError, NinoFormatError}
 
 import scala.concurrent.Future
 
 class MtdIdLookupServiceSpec extends ServiceSpec {
 
+  val nino        = "AA123456A"
+
   trait Test extends MockMtdIdLookupConnector {
     lazy val target = new MtdIdLookupService(mockMtdIdLookupConnector)
   }
 
-  val nino: String        = "AA123456A"
-  val invalidNino: String = "INVALID_NINO"
-
   "calling .getMtdId" when {
 
+    "an mtdId is found for the NINO" should {
+      "return the mtdId" in new Test {
+        val mtdId = "someMtdId"
+
+        MockedMtdIdLookupConnector.lookup(nino) returns Future.successful(Right(mtdId))
+
+        await(target.lookup(nino)) shouldBe Right(mtdId)
+      }
+    }
+
     "an invalid NINO is passed in" should {
-      "return a valid mtdId" in new Test {
+      "return NinoFormatError" in new Test {
+        val invalidNino = "INVALID_NINO"
 
-        val expected: Left[MtdError, Nothing] = Left(NinoFormatError)
-
-        // should not call the connector
-        MockedMtdIdLookupConnector
-          .lookup(invalidNino)
-          .never()
-
-        private val result = await(target.lookup(invalidNino))
-
-        result shouldBe expected
+        await(target.lookup(invalidNino)) shouldBe Left(NinoFormatError)
       }
     }
 
-    "a not authorised error occurs the service" should {
-      "proxy the error to the caller" in new Test {
-        val connectorResponse: Left[MtdError, Nothing] = Left(ClientNotAuthenticatedError)
+    "the downstream service returns a 403 status error" should {
+      "return ClientOrAgentNotAuthorisedError" in new Test {
+        MockedMtdIdLookupConnector.lookup(nino) returns Future.successful(Left(MtdIdLookupConnector.Error(FORBIDDEN)))
 
-        MockedMtdIdLookupConnector
-          .lookup(nino)
-          .returns(Future.successful(connectorResponse))
-
-        private val result = await(target.lookup(nino))
-
-        result shouldBe connectorResponse
+        await(target.lookup(nino)) shouldBe Left(ClientOrAgentNotAuthorisedError)
       }
     }
 
-    "a downstream error occurs the service" should {
-      "proxy the error to the caller" in new Test {
-        val connectorResponse: Left[MtdError, Nothing] = Left(InternalError)
+    "the downstream service returns a 401 status error" should {
+      "return InvalidBearerTokenError" in new Test {
+        MockedMtdIdLookupConnector.lookup(nino) returns Future.successful(Left(MtdIdLookupConnector.Error(UNAUTHORIZED)))
 
-        MockedMtdIdLookupConnector
-          .lookup(nino)
-          .returns(Future.successful(connectorResponse))
+        await(target.lookup(nino)) shouldBe Left(InvalidBearerTokenError)
+      }
+    }
 
-        private val result = await(target.lookup(nino))
+    "the downstream service returns another status code" should {
+      "return InternalError" in new Test {
+        MockedMtdIdLookupConnector.lookup(nino) returns Future.successful(Left(MtdIdLookupConnector.Error(IM_A_TEAPOT)))
 
-        result shouldBe connectorResponse
+        await(target.lookup(nino)) shouldBe Left(InternalError)
       }
     }
 

--- a/test/definition/ApiDefinitionFactorySpec.scala
+++ b/test/definition/ApiDefinitionFactorySpec.scala
@@ -42,7 +42,7 @@ class ApiDefinitionFactorySpec extends UnitSpec {
         MockedAppConfig.apiStatus(Version2) returns "BETA"
         MockedAppConfig.endpointsEnabled(Version1) returns true
         MockedAppConfig.endpointsEnabled(Version2) returns true
-        MockedAppConfig.confidenceLevelCheckEnabled
+        MockedAppConfig.confidenceLevelConfig
           .returns(ConfidenceLevelConfig(confidenceLevel = confidenceLevel, definitionEnabled = true, authValidationEnabled = true))
           .anyNumberOfTimes()
 
@@ -97,7 +97,7 @@ class ApiDefinitionFactorySpec extends UnitSpec {
     ).foreach { case (definitionEnabled, configCL, expectedDefinitionCL) =>
       s"confidence-level-check.definition.enabled is $definitionEnabled and confidence-level = $configCL" should {
         s"return confidence level $expectedDefinitionCL" in new Test {
-          MockedAppConfig.confidenceLevelCheckEnabled returns ConfidenceLevelConfig(
+          MockedAppConfig.confidenceLevelConfig returns ConfidenceLevelConfig(
             confidenceLevel = configCL,
             definitionEnabled = definitionEnabled,
             authValidationEnabled = true)

--- a/test/mocks/MockAppConfig.scala
+++ b/test/mocks/MockAppConfig.scala
@@ -66,7 +66,7 @@ trait MockAppConfig extends MockFactory {
     def minimumPermittedTaxYear: CallHandler[Int]                = (() => mockAppConfig.minimumPermittedTaxYear).expects()
     def ukDividendsMinimumTaxYear: CallHandler[Int]              = (() => mockAppConfig.ukDividendsMinimumTaxYear).expects()
 
-    def confidenceLevelCheckEnabled: CallHandler[ConfidenceLevelConfig] =
+    def confidenceLevelConfig: CallHandler[ConfidenceLevelConfig] =
       (() => mockAppConfig.confidenceLevelConfig).expects()
 
   }

--- a/test/utils/ErrorHandlerSpec.scala
+++ b/test/utils/ErrorHandlerSpec.scala
@@ -104,7 +104,7 @@ class ErrorHandlerSpec extends UnitSpec with GuiceOneAppPerSuite {
         private val result = handler.onClientError(requestHeader, UNAUTHORIZED, "test")
         status(result) shouldBe UNAUTHORIZED
 
-        contentAsJson(result) shouldBe ClientNotAuthenticatedError.asJson
+        contentAsJson(result) shouldBe ClientOrAgentNotAuthorisedError.asJson
       }
     }
 
@@ -143,7 +143,7 @@ class ErrorHandlerSpec extends UnitSpec with GuiceOneAppPerSuite {
         private val result = handler.onServerError(requestHeader, new InsufficientEnrolments("test") with NoStackTrace)
         status(result) shouldBe UNAUTHORIZED
 
-        contentAsJson(result) shouldBe ClientNotAuthenticatedError.asJson
+        contentAsJson(result) shouldBe ClientOrAgentNotAuthorisedError.asJson
       }
     }
 


### PR DESCRIPTION
Note: this repo does not have the parser/validator changes so `isValid` was exposed in `NinoValidation` for use in  `MtdIdLookupService`.